### PR TITLE
Monix 3.0.0.RC@ akka 2.5.17

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
 name := "streaming-benchmarks"
 
 organization := "io.monix"
-scalaVersion := "2.12.7"
+scalaVersion := "2.12.8"
 
 libraryDependencies ++= Seq(
   "io.monix"             %% "monix"       % "3.0.0-RC2",
-  "com.typesafe.akka"    %% "akka-stream" % "2.5.17",
-  "co.fs2"               %% "fs2-core"    % "1.0.0",
-  "org.typelevel"        %% "cats-effect" % "1.0.0",
-  "io.reactivex.rxjava2" %  "rxjava"      % "2.2.3"
+  "com.typesafe.akka"    %% "akka-stream" % "2.5.19",
+  "co.fs2"               %% "fs2-core"    % "1.0.2",
+  "org.typelevel"        %% "cats-effect" % "1.1.0",
+  "io.reactivex.rxjava2" %  "rxjava"      % "2.2.5"
 )
 
 enablePlugins(JmhPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")
+
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")

--- a/results/2019-01-11/ChunkedEvalFilterMapSumBenchmark.txt
+++ b/results/2019-01-11/ChunkedEvalFilterMapSumBenchmark.txt
@@ -1,0 +1,267 @@
+# JMH version: 1.21
+# VM version: JDK 10.0.1, Java HotSpot(TM) 64-Bit Server VM, 10.0.1+10
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk-10.0.1.jdk/Contents/Home/bin/java
+# VM options: <none>
+# Warmup: 10 iterations, 10 s each
+# Measurement: 10 iterations, 10 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: streaming.benchmarks.ChunkedEvalFilterMapSumBenchmark.akkaStreams
+# Parameters: (chunkCount = 1000, chunkSize = 1000)
+
+# Run progress: 0.00% complete, ETA 00:20:00
+# Fork: 1 of 1
+# Warmup Iteration   1: 11.152 ops/s
+# Warmup Iteration   2: 11.650 ops/s
+# Warmup Iteration   3: 11.734 ops/s
+# Warmup Iteration   4: 11.756 ops/s
+# Warmup Iteration   5: 11.756 ops/s
+# Warmup Iteration   6: 11.769 ops/s
+# Warmup Iteration   7: 11.775 ops/s
+# Warmup Iteration   8: 11.775 ops/s
+# Warmup Iteration   9: 11.747 ops/s
+# Warmup Iteration  10: 11.750 ops/s
+Iteration   1: 11.756 ops/s
+Iteration   2: 11.725 ops/s
+Iteration   3: 11.720 ops/s
+Iteration   4: 11.749 ops/s
+Iteration   5: 11.735 ops/s
+Iteration   6: 11.709 ops/s
+Iteration   7: 11.714 ops/s
+Iteration   8: 11.737 ops/s
+Iteration   9: 11.707 ops/s
+Iteration  10: 11.699 ops/s
+
+
+Result "streaming.benchmarks.ChunkedEvalFilterMapSumBenchmark.akkaStreams":
+  11.725 ±(99.9%) 0.028 ops/s [Average]
+  (min, avg, max) = (11.699, 11.725, 11.756), stdev = 0.019
+  CI (99.9%): [11.697, 11.754] (assumes normal distribution)
+
+
+# JMH version: 1.21
+# VM version: JDK 10.0.1, Java HotSpot(TM) 64-Bit Server VM, 10.0.1+10
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk-10.0.1.jdk/Contents/Home/bin/java
+# VM options: <none>
+# Warmup: 10 iterations, 10 s each
+# Measurement: 10 iterations, 10 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: streaming.benchmarks.ChunkedEvalFilterMapSumBenchmark.fs2Stream
+# Parameters: (chunkCount = 1000, chunkSize = 1000)
+
+# Run progress: 16.67% complete, ETA 00:17:17
+# Fork: 1 of 1
+# Warmup Iteration   1: 31.861 ops/s
+# Warmup Iteration   2: 34.177 ops/s
+# Warmup Iteration   3: 34.710 ops/s
+# Warmup Iteration   4: 34.835 ops/s
+# Warmup Iteration   5: 34.828 ops/s
+# Warmup Iteration   6: 34.609 ops/s
+# Warmup Iteration   7: 34.659 ops/s
+# Warmup Iteration   8: 35.001 ops/s
+# Warmup Iteration   9: 34.637 ops/s
+# Warmup Iteration  10: 34.736 ops/s
+Iteration   1: 34.726 ops/s
+Iteration   2: 34.530 ops/s
+Iteration   3: 34.451 ops/s
+Iteration   4: 34.774 ops/s
+Iteration   5: 35.134 ops/s
+Iteration   6: 34.894 ops/s
+Iteration   7: 34.431 ops/s
+Iteration   8: 34.889 ops/s
+Iteration   9: 34.904 ops/s
+Iteration  10: 34.752 ops/s
+
+
+Result "streaming.benchmarks.ChunkedEvalFilterMapSumBenchmark.fs2Stream":
+  34.748 ±(99.9%) 0.339 ops/s [Average]
+  (min, avg, max) = (34.431, 34.748, 35.134), stdev = 0.224
+  CI (99.9%): [34.410, 35.087] (assumes normal distribution)
+
+
+# JMH version: 1.21
+# VM version: JDK 10.0.1, Java HotSpot(TM) 64-Bit Server VM, 10.0.1+10
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk-10.0.1.jdk/Contents/Home/bin/java
+# VM options: <none>
+# Warmup: 10 iterations, 10 s each
+# Measurement: 10 iterations, 10 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: streaming.benchmarks.ChunkedEvalFilterMapSumBenchmark.monixIterant
+# Parameters: (chunkCount = 1000, chunkSize = 1000)
+
+# Run progress: 33.33% complete, ETA 00:13:48
+# Fork: 1 of 1
+# Warmup Iteration   1: 60.445 ops/s
+# Warmup Iteration   2: 61.235 ops/s
+# Warmup Iteration   3: 61.543 ops/s
+# Warmup Iteration   4: 62.443 ops/s
+# Warmup Iteration   5: 62.301 ops/s
+# Warmup Iteration   6: 62.570 ops/s
+# Warmup Iteration   7: 62.608 ops/s
+# Warmup Iteration   8: 61.900 ops/s
+# Warmup Iteration   9: 62.584 ops/s
+# Warmup Iteration  10: 62.037 ops/s
+Iteration   1: 58.626 ops/s
+Iteration   2: 56.652 ops/s
+Iteration   3: 56.477 ops/s
+Iteration   4: 56.639 ops/s
+Iteration   5: 56.823 ops/s
+Iteration   6: 56.079 ops/s
+Iteration   7: 56.583 ops/s
+Iteration   8: 57.084 ops/s
+Iteration   9: 56.632 ops/s
+Iteration  10: 57.004 ops/s
+
+
+Result "streaming.benchmarks.ChunkedEvalFilterMapSumBenchmark.monixIterant":
+  56.860 ±(99.9%) 1.029 ops/s [Average]
+  (min, avg, max) = (56.079, 56.860, 58.626), stdev = 0.681
+  CI (99.9%): [55.831, 57.889] (assumes normal distribution)
+
+
+# JMH version: 1.21
+# VM version: JDK 10.0.1, Java HotSpot(TM) 64-Bit Server VM, 10.0.1+10
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk-10.0.1.jdk/Contents/Home/bin/java
+# VM options: <none>
+# Warmup: 10 iterations, 10 s each
+# Measurement: 10 iterations, 10 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: streaming.benchmarks.ChunkedEvalFilterMapSumBenchmark.monixObservable
+# Parameters: (chunkCount = 1000, chunkSize = 1000)
+
+# Run progress: 50.00% complete, ETA 00:10:21
+# Fork: 1 of 1
+# Warmup Iteration   1: 72.328 ops/s
+# Warmup Iteration   2: 73.179 ops/s
+# Warmup Iteration   3: 74.942 ops/s
+# Warmup Iteration   4: 72.688 ops/s
+# Warmup Iteration   5: 73.323 ops/s
+# Warmup Iteration   6: 73.342 ops/s
+# Warmup Iteration   7: 74.192 ops/s
+# Warmup Iteration   8: 72.447 ops/s
+# Warmup Iteration   9: 73.087 ops/s
+# Warmup Iteration  10: 73.425 ops/s
+Iteration   1: 74.708 ops/s
+Iteration   2: 73.296 ops/s
+Iteration   3: 74.056 ops/s
+Iteration   4: 73.002 ops/s
+Iteration   5: 73.883 ops/s
+Iteration   6: 73.666 ops/s
+Iteration   7: 72.997 ops/s
+Iteration   8: 73.496 ops/s
+Iteration   9: 74.890 ops/s
+Iteration  10: 72.410 ops/s
+
+
+Result "streaming.benchmarks.ChunkedEvalFilterMapSumBenchmark.monixObservable":
+  73.640 ±(99.9%) 1.172 ops/s [Average]
+  (min, avg, max) = (72.410, 73.640, 74.890), stdev = 0.775
+  CI (99.9%): [72.468, 74.812] (assumes normal distribution)
+
+
+# JMH version: 1.21
+# VM version: JDK 10.0.1, Java HotSpot(TM) 64-Bit Server VM, 10.0.1+10
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk-10.0.1.jdk/Contents/Home/bin/java
+# VM options: <none>
+# Warmup: 10 iterations, 10 s each
+# Measurement: 10 iterations, 10 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: streaming.benchmarks.ChunkedEvalFilterMapSumBenchmark.rxJavaFlowable
+# Parameters: (chunkCount = 1000, chunkSize = 1000)
+
+# Run progress: 66.67% complete, ETA 00:06:54
+# Fork: 1 of 1
+# Warmup Iteration   1: 54.162 ops/s
+# Warmup Iteration   2: 55.652 ops/s
+# Warmup Iteration   3: 54.755 ops/s
+# Warmup Iteration   4: 55.510 ops/s
+# Warmup Iteration   5: 55.582 ops/s
+# Warmup Iteration   6: 55.600 ops/s
+# Warmup Iteration   7: 55.100 ops/s
+# Warmup Iteration   8: 56.008 ops/s
+# Warmup Iteration   9: 55.358 ops/s
+# Warmup Iteration  10: 55.580 ops/s
+Iteration   1: 55.586 ops/s
+Iteration   2: 54.910 ops/s
+Iteration   3: 55.894 ops/s
+Iteration   4: 55.602 ops/s
+Iteration   5: 55.346 ops/s
+Iteration   6: 55.228 ops/s
+Iteration   7: 55.437 ops/s
+Iteration   8: 55.538 ops/s
+Iteration   9: 55.534 ops/s
+Iteration  10: 55.433 ops/s
+
+
+Result "streaming.benchmarks.ChunkedEvalFilterMapSumBenchmark.rxJavaFlowable":
+  55.451 ±(99.9%) 0.392 ops/s [Average]
+  (min, avg, max) = (54.910, 55.451, 55.894), stdev = 0.259
+  CI (99.9%): [55.058, 55.843] (assumes normal distribution)
+
+
+# JMH version: 1.21
+# VM version: JDK 10.0.1, Java HotSpot(TM) 64-Bit Server VM, 10.0.1+10
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk-10.0.1.jdk/Contents/Home/bin/java
+# VM options: <none>
+# Warmup: 10 iterations, 10 s each
+# Measurement: 10 iterations, 10 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: streaming.benchmarks.ChunkedEvalFilterMapSumBenchmark.rxJavaObservable
+# Parameters: (chunkCount = 1000, chunkSize = 1000)
+
+# Run progress: 83.33% complete, ETA 00:03:26
+# Fork: 1 of 1
+# Warmup Iteration   1: 63.111 ops/s
+# Warmup Iteration   2: 63.567 ops/s
+# Warmup Iteration   3: 62.710 ops/s
+# Warmup Iteration   4: 63.305 ops/s
+# Warmup Iteration   5: 63.484 ops/s
+# Warmup Iteration   6: 63.459 ops/s
+# Warmup Iteration   7: 63.517 ops/s
+# Warmup Iteration   8: 63.221 ops/s
+# Warmup Iteration   9: 63.912 ops/s
+# Warmup Iteration  10: 62.990 ops/s
+Iteration   1: 64.321 ops/s
+Iteration   2: 63.545 ops/s
+Iteration   3: 63.845 ops/s
+Iteration   4: 62.771 ops/s
+Iteration   5: 62.726 ops/s
+Iteration   6: 62.910 ops/s
+Iteration   7: 63.823 ops/s
+Iteration   8: 63.091 ops/s
+Iteration   9: 64.157 ops/s
+Iteration  10: 63.729 ops/s
+
+
+Result "streaming.benchmarks.ChunkedEvalFilterMapSumBenchmark.rxJavaObservable":
+  63.492 ±(99.9%) 0.877 ops/s [Average]
+  (min, avg, max) = (62.726, 63.492, 64.321), stdev = 0.580
+  CI (99.9%): [62.615, 64.369] (assumes normal distribution)
+
+
+# Run complete. Total time: 00:20:41
+
+REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
+why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
+experiments, perform baseline and negative tests that provide experimental control, make sure
+the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
+Do not assume the numbers tell you what you want them to tell.
+
+Benchmark                                          (chunkCount)  (chunkSize)   Mode  Cnt   Score   Error  Units
+ChunkedEvalFilterMapSumBenchmark.akkaStreams               1000         1000  thrpt   10  11.725 ± 0.028  ops/s
+ChunkedEvalFilterMapSumBenchmark.fs2Stream                 1000         1000  thrpt   10  34.748 ± 0.339  ops/s
+ChunkedEvalFilterMapSumBenchmark.monixIterant              1000         1000  thrpt   10  56.860 ± 1.029  ops/s
+ChunkedEvalFilterMapSumBenchmark.monixObservable           1000         1000  thrpt   10  73.640 ± 1.172  ops/s
+ChunkedEvalFilterMapSumBenchmark.rxJavaFlowable            1000         1000  thrpt   10  55.451 ± 0.392  ops/s
+ChunkedEvalFilterMapSumBenchmark.rxJavaObservable          1000         1000  thrpt   10  63.492 ± 0.877  ops/s

--- a/results/2019-01-11/index.md
+++ b/results/2019-01-11/index.md
@@ -1,0 +1,14 @@
+# Results 2018-11-18
+
+## ChunkedEvalFilterMapSumBenchmark
+
+Results:
+
+| Library            | Stream type + IO type          | ops/s  | error |
+|--------------------|--------------------------------|--------|-------|
+| monix  3.0.0-RC2   | Observable + MonixTask         | 73.640 | 1.172 |
+| rxjava 2.2.5       | Observable + Single + Callable | 63.492 | 0.877 |
+| monix 3.0.0-RC2    | Iterant + MonixTask            | 56.860 | 1.029 |
+| rxjava 2.2.5       | Flowable + Single + Callable   | 55.451 | 0.392 | 
+| fs2-core 1.0.2     | Stream + MonixTask             | 34.748 | 0.339 |
+| akka-stream 2.5.19 | Source + scala Future          | 11.725 | 0.028 |


### PR DESCRIPTION
Update to benchmark deps:
akka-stream - 2.5.19
fs2-core -1.0.2
cats-effect - 1.1.0
RreactiveX.RxJava2 - 2.2.5

Results suggest Monix Observable with Task is the winning duo:

 | Library            | Stream type + IO type          | ops/s  | error |
|--------------------|--------------------------------|--------|-------|
| monix  3.0.0-RC2   | Observable + MonixTask         | 73.640 | 1.172 |
| rxjava 2.2.5       | Observable + Single + Callable | 63.492 | 0.877 |
| monix 3.0.0-RC2    | Iterant + MonixTask            | 56.860 | 1.029 |
| rxjava 2.2.5       | Flowable + Single + Callable   | 55.451 | 0.392 | 
| fs2-core 1.0.2     | Stream + MonixTask             | 34.748 | 0.339 |
| akka-stream 2.5.19 | Source + scala Future          | 11.725 | 0.028 |
